### PR TITLE
Fix "UTF-8 BOM plus xml decl of ISO-8859-1 is incompatible"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -13,7 +13,7 @@
 
     <groupId>com.kohlschutter.mavenplugins</groupId>
     <artifactId>copy-rename-maven-plugin</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>maven-plugin</packaging>
 
     <name>Copy Rename Maven Plugin</name>


### PR DESCRIPTION
When trying to use the plugin in a modern (3.9.x) Maven, following error happens:

```
ERROR] Plugin com.kohlschutter.mavenplugins:copy-rename-maven-plugin:2.0.0 or one of its dependencies could not be resolved: Failed to read artifact descriptor for com.kohlschutter.mavenplugins:copy-rename-maven-plugin:jar:2.0.0: 1 problem was encountered while building the effective model
[ERROR] [FATAL] Non-parseable POM ${HOME}/.m2/repository/com/kohlschutter/mavenplugins/copy-rename-maven-plugin/2.0.0/copy-rename-maven-plugin-2.0.0.pom: UTF-8 BOM plus xml decl of ISO-8859-1 is incompatible (position: START_DOCUMENT seen <?xml version="1.0" encoding="ISO-8859-1"... @1:42) @ line 1, column 42
```

A solution it to use UTF-8 encoding in both BOM and POM XML header.